### PR TITLE
feat: enable R8 minification and resource shrinking

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,7 +19,12 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
     }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,39 @@
+# ──────────────────────────────────────────────
+# kotlinx.serialization
+# The plugin generates $$serializer classes; keep them so R8 doesn't strip
+# the companion objects that Retrofit's converter needs at runtime.
+# ──────────────────────────────────────────────
+-keepattributes *Annotation*, InnerClasses
+-keep,includedescriptorclasses class com.wassupluke.simpleweather.**$$serializer { *; }
+-keepclassmembers class com.wassupluke.simpleweather.** {
+    *** Companion;
+}
+-keepclasseswithmembers class com.wassupluke.simpleweather.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# ──────────────────────────────────────────────
+# Retrofit
+# Keep annotated interface methods; R8 cannot see calls made via dynamic proxy.
+# ──────────────────────────────────────────────
+-keepattributes Signature, Exceptions
+-keepclasseswithmembers interface * {
+    @retrofit2.http.* <methods>;
+}
+
+# ──────────────────────────────────────────────
+# WorkManager
+# Worker subclasses are instantiated by name via reflection.
+# ──────────────────────────────────────────────
+-keep class com.wassupluke.simpleweather.worker.WeatherFetchWorker {
+    public <init>(android.content.Context, androidx.work.WorkerParameters);
+}
+
+# ──────────────────────────────────────────────
+# OkHttp / Okio
+# These classes are optional on some platforms; suppress R8 warnings.
+# ──────────────────────────────────────────────
+-dontwarn okhttp3.internal.platform.**
+-dontwarn org.conscrypt.**
+-dontwarn org.bouncycastle.**
+-dontwarn org.openjsse.**


### PR DESCRIPTION
## Summary

- Enables `isMinifyEnabled = true` and `isShrinkResources = true` on release builds
- Adds `proguard-rules.pro` with targeted rules for this app's stack
- Uses `proguard-android-optimize.txt` as the base (R8 full mode)

## ProGuard rules rationale

| Rule | Why needed |
|-|-|
| kotlinx.serialization `$$serializer` companions | R8 strips companion objects used by Retrofit's serialization converter |
| Retrofit `@http.*` interface methods | Called via dynamic proxy — R8 can't see the call sites |
| `WeatherFetchWorker` constructor | WorkManager instantiates workers by reflection |
| OkHttp `-dontwarn` | Optional platform classes not present on Android |

Libraries that ship their own consumer rules (no custom rules needed): WorkManager, Glance, DataStore, Compose.

## Test plan

- [x] `./gradlew assembleRelease` builds successfully with no R8 errors
- [ ] Install signed release APK and verify widget displays temperature
- [ ] Verify settings screen saves and applies all settings
- [ ] Verify WorkManager fetch triggers and updates widget

## Summary by Sourcery

Enable release build code and resource shrinking with R8 and add supporting ProGuard configuration.

Enhancements:
- Add a ProGuard rules file tailored for serialization, Retrofit, WorkManager, and OkHttp stack to ensure correct runtime behavior under R8.

Build:
- Turn on R8 code minification and resource shrinking for release builds and wire in default and custom ProGuard rule files.