### PR TITLE
chore: enable configuration cache and parallel GC

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,4 +7,5 @@ android.r8.strictFullModeForKeepRules=false
 android.builtInKotlin=true
 
 # Increase heap size for Gradle daemon
-org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.configuration-cache=true


### PR DESCRIPTION
## Summary
- Enables Gradle configuration cache (`org.gradle.configuration-cache=true`) — skips the configuration phase on repeat builds, which is the biggest incremental build win available for a single-module project
- Switches JVM GC to `-XX:+UseParallelGC` — performs better than G1 for short-lived Gradle daemon workloads

## Test plan
- [ ] Run a full build, then a second build and confirm "Configuration cache entry reused" appears in Gradle output
- [ ] Verify no configuration cache incompatibilities surface (warnings are fine; errors are not)

## Summary by Sourcery

Enable Gradle configuration caching and adjust JVM settings to optimize build performance.

Build:
- Enable Gradle configuration cache in Gradle properties.
- Switch Gradle daemon JVM to use Parallel GC for improved short-lived build workloads.