### PR TITLE
feat: auto-publish pre-release APK on every push to main

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -43,25 +43,22 @@ jobs:
         env:
           BUILD_TOOLS_VERSION: "35.0.0"
 
-      - name: Compute tag name
-        id: tag
-        run: echo "name=nightly-$(date -u +'%Y%m%d')-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
-
       - name: Rename APK
         id: rename_apk
         run: |
-          RENAMED="simple-weather-${{ steps.tag.outputs.name }}.apk"
+          RENAMED="simple-weather-dev-${GITHUB_SHA::6}.apk"
           mv "${{ steps.sign_app.outputs.signedReleaseFile }}" "$RENAMED"
           echo "apk_path=$RENAMED" >> $GITHUB_OUTPUT
 
-      - name: Create GitHub Pre-release
+      - name: Create or update dev pre-release
         uses: softprops/action-gh-release@v2
         with:
           files: ${{ steps.rename_apk.outputs.apk_path }}
-          name: Nightly ${{ steps.tag.outputs.name }}
-          tag_name: ${{ steps.tag.outputs.name }}
+          name: Dev Build
+          tag_name: dev
           draft: false
           prerelease: true
+          make_latest: false
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/prerelease.yml` triggered on every push to `main`
- Builds, signs, and publishes a GitHub pre-release tagged `nightly-YYYYMMDD-<sha>`
- Uses the same signing secrets as the existing `release.yml` workflow
- GitHub auto-generates release notes from commits since the previous release

## Notes
- Pre-release tags are distinct from versioned tags (`v*`) used by the existing release workflow — no conflicts
- Each push produces a new pre-release; old ones can be cleaned up manually or with a future retention workflow

## Test plan
- [ ] Merge this PR and confirm the workflow runs and produces a pre-release on the GitHub Releases page
- [ ] Verify the signed APK installs on a device

## Summary by Sourcery

CI:
- Introduce a prerelease GitHub Actions workflow that builds the release APK, signs it with existing signing secrets, and publishes a nightly GitHub pre-release tagged with the commit SHA.