### PR TITLE
ignore build/release files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+# Built application files
+*.apk
+*.aar
+*.ap_
+*.aab
+
+# Files for the ART/Dalvik VM
+*.dex
+
 # Git worktrees
 .worktrees/
 
@@ -9,6 +18,8 @@
 *.hprof
 .gradle/
 build/
+release/
+app/release/
 local.properties
 
 # IDE


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Change version-controlled build configuration to ignore build and release output files.