### PR TITLE
feat: derive versionCode and versionName from git at build time

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,14 @@ plugins {
     alias(libs.plugins.kotlin.compose)
 }
 
+val gitVersionCode = providers.exec {
+    commandLine("git", "rev-list", "--count", "HEAD")
+}.standardOutput.asText.map { it.trim().toIntOrNull() ?: 1 }
+
+val gitVersionName = providers.exec {
+    commandLine("git", "describe", "--tags", "--always")
+}.standardOutput.asText.map { it.trim().removePrefix("v").ifEmpty { "0.0.0" } }
+
 android {
     namespace = "com.wassupluke.simpleweather"
     compileSdk = 36
@@ -12,8 +20,8 @@ android {
         applicationId = "com.wassupluke.simpleweather"
         minSdk = 26
         targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = gitVersionCode.get()
+        versionName = gitVersionName.get()
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
## Summary

- Replaces hardcoded `versionCode = 1` / `versionName = "1.0"` with values derived from git at build time
- `versionCode` = total commit count (always monotonically increasing)
- `versionName` = `git describe --tags --always` with `v` prefix stripped (e.g. `v1.2.0` → `1.2.0`; between tags → `1.2.0-3-gabcdef`)
- Uses `providers.exec` (Gradle 8.2+) — configuration-cache safe, no extra dependencies

## Test Plan

- [ ] `./gradlew assembleDebug` builds successfully
- [ ] `./gradlew :app:testDebugUnitTest` passes
- [ ] After pushing a `vX.Y.Z` tag, the release build reflects that version name

## Summary by Sourcery

Derive the Android app’s versionCode and versionName from the current git repository state at build time instead of using hardcoded values.

New Features:
- Compute versionCode from the total git commit count on HEAD.
- Compute versionName from `git describe --tags --always`, stripping any leading `v` and defaulting to a placeholder when absent.