### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,5 +1,8 @@
 name: CI Check
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/wassupluke/simple-weather/security/code-scanning/1](https://github.com/wassupluke/simple-weather/security/code-scanning/1)

To fix the problem, explicitly set minimal `GITHUB_TOKEN` permissions in the workflow. Since this job only checks out code and runs local Gradle commands, it needs only read access to repository contents. The recommended general fix is to add a `permissions` section either at the workflow root (so it applies to all jobs) or directly under the `check` job definition, specifying `contents: read`.

The single best way here, without changing functionality, is to define `permissions` at the workflow root just after `name:` and before `on:`. This will apply to all jobs that don’t override permissions and clearly documents that the workflow only requires read access to repository contents. Concretely, in `.github/workflows/check.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 2 (the blank line after `name: CI Check`) and line 3 (`on:`). No imports or additional definitions are needed, as this is standard GitHub Actions YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Build:
- Set minimal GITHUB_TOKEN permissions (contents: read) at the root of the CI check workflow configuration to follow least-privilege recommendations.