### PR TITLE
fix: app picker shows all installed apps on API 30+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,13 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent>
+    </queries>
+
     <application
         android:allowBackup="true"
         android:enableOnBackInvokedCallback="true"


### PR DESCRIPTION
## Summary
- Adds a `<queries>` element to `AndroidManifest.xml` declaring `ACTION_MAIN` + `CATEGORY_LAUNCHER`
- Without this, Android 11+ (API 30+) package visibility restrictions cause `queryIntentActivities` to return only a handful of visible system apps instead of all installed apps
- No permission required — `<queries>` is the correct, Play-compliant solution

## Test Plan
- [ ] Open Settings → Widget tap action → tap the row
- [ ] Bottom sheet now shows all installed apps, not just 4 system apps

## Summary by Sourcery

New Features:
- Enable querying of all launcher activities via a manifest <queries> declaration to support the app picker on newer Android versions.