### PR TITLE
fix: use primary color for widget temperature text

### DIFF
--- a/app/src/main/java/com/wassupluke/simpleweather/widget/WeatherWidget.kt
+++ b/app/src/main/java/com/wassupluke/simpleweather/widget/WeatherWidget.kt
@@ -44,7 +44,7 @@ class WeatherWidget : GlanceAppWidget() {
                 }
 
                 val textColorProvider: ColorProvider = if (dynamicColor) {
-                    GlanceTheme.colors.onBackground
+                    GlanceTheme.colors.primary
                 } else {
                     val resolved = parseColorSafe(colorString)?.let { argb ->
                         Color(

--- a/docs/plans/2026-03-25-dynamic-color-widget-design.md
+++ b/docs/plans/2026-03-25-dynamic-color-widget-design.md
@@ -33,7 +33,7 @@ val WIDGET_DYNAMIC_COLOR = booleanPreferencesKey("widget_dynamic_color")
 `WeatherWidget.kt` wraps `WeatherWidgetContent` in `GlanceTheme { }`.
 
 Color resolution:
-- `dynamicColor = true`, API 31+: use `GlanceTheme.colors.onBackground`
+- `dynamicColor = true`, API 31+: use `GlanceTheme.colors.primary`
 - `dynamicColor = true`, pre-API 31: `ColorProvider(Color.White)` fallback
 - `dynamicColor = false`: existing `ColorProvider(textColor)` path, unchanged
 
@@ -57,5 +57,5 @@ Color resolution:
 ## Non-Goals
 
 - No manual palette extraction (`WallpaperManager` API not used)
-- No dark/light mode color override — `GlanceTheme.colors.onBackground` handles this automatically
+- No dark/light mode color override — `GlanceTheme.colors.primary` handles this automatically
 - No UI on pre-API 31 devices

--- a/docs/plans/2026-03-25-dynamic-color-widget.md
+++ b/docs/plans/2026-03-25-dynamic-color-widget.md
@@ -205,7 +205,7 @@ git commit -m "feat: add widgetDynamicColor to SettingsViewModel with smart-defa
 
 **Background — Glance color resolution:**
 
-`GlanceTheme` (from `androidx.glance.material3`) is a Composable that provides Material You colors. Inside it, `GlanceTheme.colors.onBackground` is a `ColorProvider` that resolves to the wallpaper-seeded palette on API 31+, and a baseline scheme below that. We pass `ColorProvider` directly to `WeatherWidgetContent` rather than a resolved `Color`, so Glance can perform light/dark resolution at render time.
+`GlanceTheme` (from `androidx.glance.material3`) is a Composable that provides Material You colors. Inside it, `GlanceTheme.colors.primary` is a `ColorProvider` that resolves to the wallpaper-seeded palette on API 31+, and a baseline scheme below that. We pass `ColorProvider` directly to `WeatherWidgetContent` rather than a resolved `Color`, so Glance can perform light/dark resolution at render time.
 
 **Step 1: Apply the changes**
 
@@ -260,7 +260,7 @@ class WeatherWidget : GlanceAppWidget() {
 
                 val textColorProvider: ColorProvider = when {
                     dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ->
-                        GlanceTheme.colors.onBackground
+                        GlanceTheme.colors.primary
                     dynamicColor ->
                         ColorProvider(Color.White)
                     else -> {


### PR DESCRIPTION
## Summary
- Replace `onBackground` with `primary` for the widget temperature text color
- `primary` uses the Material You wallpaper-seeded accent color, giving a more saturated, vibrant appearance that adapts to the user's wallpaper

## Test Plan
- [ ] Verify widget temperature text renders with the wallpaper accent color when dynamic color is enabled
- [ ] Verify fallback color still renders correctly when dynamic color is disabled

## Summary by Sourcery

Documentation:
- Refresh dynamic color widget design docs to reflect use of the primary color for temperature text instead of onBackground.