### PR TITLE
fix: use getLaunchIntentForPackage for alarm source filtering

### DIFF
--- a/app/src/main/java/com/wassupluke/widgets/widget/AlarmWidgetReceiver.kt
+++ b/app/src/main/java/com/wassupluke/widgets/widget/AlarmWidgetReceiver.kt
@@ -4,7 +4,6 @@ import android.app.AlarmManager
 import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import androidx.datastore.preferences.core.edit
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
@@ -59,11 +58,6 @@ class AlarmWidgetReceiver : GlanceAppWidgetReceiver() {
         }
     }
 
-    private fun isUserFacingApp(context: Context, packageName: String): Boolean {
-        val intent = Intent(Intent.ACTION_MAIN).apply {
-            addCategory(Intent.CATEGORY_LAUNCHER)
-            setPackage(packageName)
-        }
-        return context.packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY).isNotEmpty()
-    }
+    private fun isUserFacingApp(context: Context, packageName: String): Boolean =
+        context.packageManager.getLaunchIntentForPackage(packageName) != null
 }


### PR DESCRIPTION
## Summary

- `isUserFacingApp()` used `queryIntentActivities` with `MATCH_DEFAULT_ONLY`, which requires `CATEGORY_DEFAULT` in the target's intent filter
- Standard launcher activities only declare `CATEGORY_LAUNCHER` (not `CATEGORY_DEFAULT`), so the query always returned empty — alarm widget showed "No alarm" for every clock app including Google Clock
- Replaced with `getLaunchIntentForPackage()`, Android's built-in API for this check, already used in both widgets' tap-action resolution

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` passes
- [ ] Set an alarm in Google Clock (or device default clock app), confirm alarm widget displays the alarm time instead of "No alarm"
- [ ] With no alarm set, confirm widget still shows "No alarm"

## Summary by Sourcery

Bug Fixes:
- Fix alarm widget incorrectly showing "No alarm" for valid clock apps by updating the user-facing app detection logic.