### PR TITLE
fix: force widget re-render on app launch to recover Glance state

### DIFF
--- a/app/src/main/java/com/wassupluke/widgets/ui/MainActivity.kt
+++ b/app/src/main/java/com/wassupluke/widgets/ui/MainActivity.kt
@@ -21,7 +21,10 @@ import com.wassupluke.widgets.data.dataStore
 import com.wassupluke.widgets.ui.settings.SettingsScreen
 import com.wassupluke.widgets.ui.settings.SettingsViewModel
 import com.wassupluke.widgets.ui.theme.SimpleWeatherTheme
+import com.wassupluke.widgets.widget.AlarmWidget
+import com.wassupluke.widgets.widget.WeatherWidget
 import com.wassupluke.widgets.worker.WorkScheduler
+import androidx.glance.appwidget.updateAll
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -53,8 +56,13 @@ class MainActivity : ComponentActivity() {
             }
         }
 
-        // Schedule WorkManager on first launch (if location is already set)
         lifecycleScope.launch(Dispatchers.IO) {
+            // Force both widgets to re-render, re-establishing correct Glance
+            // state mapping in case it drifted after a force-stop or update
+            WeatherWidget().updateAll(applicationContext)
+            AlarmWidget().updateAll(applicationContext)
+
+            // Schedule WorkManager (if location is already set)
             val prefs = applicationContext.dataStore.data.first()
             val lat = prefs[WeatherDataStore.LOCATION_LAT]
             val lon = prefs[WeatherDataStore.LOCATION_LON]


### PR DESCRIPTION
## Summary
- Glance's internal `appWidgetId`→class mapping can become stale after force-stop or app update, causing one widget to render the other's content and tap targets
- Calls `updateAll` for both `WeatherWidget` and `AlarmWidget` on every app launch, forcing Glance to re-render with the correct `provideGlance` and re-establish its state mapping
- Uninstall/reinstall fixes the issue permanently, but this mitigation self-heals on the next app open

Mitigates #23

## Test plan
- [ ] Place both weather and alarm widgets on home screen
- [ ] Force-stop the app, then reopen it
- [ ] Verify both widgets show their correct content (temp vs alarm) and tap targets

## Summary by Sourcery

Bug Fixes:
- Ensure weather and alarm widgets re-render with the correct content and tap targets by calling Glance updateAll for both widgets whenever the app is opened.