### PR TITLE
refactor: extract shared tap-action helper and skip no-op alarm updates

### DIFF
--- a/app/src/main/java/com/wassupluke/widgets/widget/AlarmWidget.kt
+++ b/app/src/main/java/com/wassupluke/widgets/widget/AlarmWidget.kt
@@ -11,7 +11,6 @@ import androidx.datastore.preferences.core.emptyPreferences
 import androidx.compose.ui.unit.dp
 import androidx.glance.*
 import androidx.glance.action.Action
-import androidx.glance.action.actionStartActivity
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.provideContent
@@ -30,7 +29,6 @@ import com.wassupluke.widgets.data.WeatherDataStore
 import com.wassupluke.widgets.data.dataStore
 import com.wassupluke.widgets.data.parseColorSafe
 import com.wassupluke.widgets.data.resolveDynamicColor
-import com.wassupluke.widgets.ui.MainActivity
 
 @SuppressLint("RestrictedApi")
 class AlarmWidget : GlanceAppWidget() {
@@ -51,14 +49,7 @@ class AlarmWidget : GlanceAppWidget() {
                     ColorProvider(Color(argb))
                 }
 
-                val tapPackage = prefs[WeatherDataStore.ALARM_WIDGET_TAP_PACKAGE]
-                val tapAction: Action = if (!tapPackage.isNullOrEmpty()) {
-                    val launchIntent = context.packageManager.getLaunchIntentForPackage(tapPackage)
-                    if (launchIntent?.component != null) actionStartActivity(launchIntent.component!!)
-                    else actionStartActivity<MainActivity>()
-                } else {
-                    actionStartActivity<MainActivity>()
-                }
+                val tapAction = resolveTapAction(context, prefs[WeatherDataStore.ALARM_WIDGET_TAP_PACKAGE])
 
                 AlarmWidgetContent(
                     alarmText = alarmText,

--- a/app/src/main/java/com/wassupluke/widgets/widget/AlarmWidgetReceiver.kt
+++ b/app/src/main/java/com/wassupluke/widgets/widget/AlarmWidgetReceiver.kt
@@ -13,6 +13,7 @@ import com.wassupluke.widgets.data.WeatherDataStore
 import com.wassupluke.widgets.data.dataStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.text.DateFormat
 import java.util.Date
@@ -50,8 +51,11 @@ class AlarmWidgetReceiver : GlanceAppWidgetReceiver() {
                         context.getString(R.string.widget_alarm_none)
                     }
                 }
-                context.dataStore.edit { it[WeatherDataStore.ALARM_TEXT] = alarmText }
-                AlarmWidget().updateAll(context)
+                val current = context.dataStore.data.first()[WeatherDataStore.ALARM_TEXT]
+                if (alarmText != current) {
+                    context.dataStore.edit { it[WeatherDataStore.ALARM_TEXT] = alarmText }
+                    AlarmWidget().updateAll(context)
+                }
             } finally {
                 pendingResult?.finish()
             }

--- a/app/src/main/java/com/wassupluke/widgets/widget/WeatherWidget.kt
+++ b/app/src/main/java/com/wassupluke/widgets/widget/WeatherWidget.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.unit.sp
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.glance.*
 import androidx.glance.action.Action
-import androidx.glance.action.actionStartActivity
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.provideContent
@@ -24,7 +23,6 @@ import com.wassupluke.widgets.data.WeatherDataStore
 import com.wassupluke.widgets.data.dataStore
 import com.wassupluke.widgets.data.parseColorSafe
 import com.wassupluke.widgets.data.resolveDynamicColor
-import com.wassupluke.widgets.ui.MainActivity
 import kotlin.math.roundToInt
 
 @SuppressLint("RestrictedApi")
@@ -53,14 +51,7 @@ class WeatherWidget : GlanceAppWidget() {
                     ColorProvider(Color(argb))
                 }
 
-                val tapPackage = prefs[WeatherDataStore.WIDGET_TAP_PACKAGE]
-                val tapAction = if (!tapPackage.isNullOrEmpty()) {
-                    val launchIntent = context.packageManager.getLaunchIntentForPackage(tapPackage)
-                    if (launchIntent?.component != null) actionStartActivity(launchIntent.component!!)
-                    else actionStartActivity<MainActivity>()
-                } else {
-                    actionStartActivity<MainActivity>()
-                }
+                val tapAction = resolveTapAction(context, prefs[WeatherDataStore.WIDGET_TAP_PACKAGE])
 
                 val fontSize = prefs[WeatherDataStore.FONT_SIZE] ?: WeatherDataStore.DEFAULT_FONT_SIZE
 

--- a/app/src/main/java/com/wassupluke/widgets/widget/WidgetTapAction.kt
+++ b/app/src/main/java/com/wassupluke/widgets/widget/WidgetTapAction.kt
@@ -1,0 +1,14 @@
+package com.wassupluke.widgets.widget
+
+import android.content.Context
+import androidx.glance.action.Action
+import androidx.glance.action.actionStartActivity
+import com.wassupluke.widgets.ui.MainActivity
+
+internal fun resolveTapAction(context: Context, tapPackage: String?): Action {
+    if (!tapPackage.isNullOrEmpty()) {
+        val launchIntent = context.packageManager.getLaunchIntentForPackage(tapPackage)
+        if (launchIntent?.component != null) return actionStartActivity(launchIntent.component!!)
+    }
+    return actionStartActivity<MainActivity>()
+}


### PR DESCRIPTION
## Summary

- Extracts the duplicate `getLaunchIntentForPackage` + fallback-to-`MainActivity` logic from both `WeatherWidget` and `AlarmWidget` into a single `resolveTapAction()` helper in `WidgetTapAction.kt`. Each widget still reads from its own DataStore key (`WIDGET_TAP_PACKAGE` / `ALARM_WIDGET_TAP_PACKAGE`), so per-widget tap targets are independent and unchanged.
- Adds a change-detection guard in `AlarmWidgetReceiver.updateAlarmText()` so the DataStore write and `updateAll()` call are skipped when the alarm text hasn't changed, avoiding redundant recompositions on repeated broadcasts.

## Test plan

- [ ] Add a weather widget and alarm widget — verify each can independently set a different tap target app
- [ ] Trigger an alarm broadcast with no alarm change — verify widget does not recompose (check logs for no DataStore write)
- [ ] Trigger an alarm broadcast with a real alarm change — verify widget updates correctly
- [ ] Build passes: `./gradlew :app:compileDebugKotlin`

## Summary by Sourcery

Refactor widget tap handling into a shared helper and avoid unnecessary alarm widget updates when the alarm text is unchanged.

Enhancements:
- Extract a shared tap-action resolver used by both the weather and alarm widgets while preserving their independent configuration.
- Skip DataStore writes and widget updates for alarm broadcasts when the alarm text has not changed to reduce redundant recompositions.