### PR TITLE
ci: fix dev-release versionCode (fetch-depth: 0)

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
`dev-release.yml`'s checkout used the default shallow fetch (`fetch-depth: 1`), so `gitVersionCode = git rev-list --count HEAD` returned 1 and fell back via `?: 1`. Dev-build APKs therefore shipped with `versionCode 1` (can't update over real installs).

Adds `fetch-depth: 0` so the dev build's versionCode reflects the true commit count, matching `release.yml` (which already sets it).

## Summary by Sourcery

CI:
- Set checkout in dev-release GitHub Actions workflow to use fetch-depth: 0 to match release workflow behavior.