### PR TITLE
fix: versionName ignores the force-pushed dev tag

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,7 +9,8 @@ val gitVersionCode = providers.exec {
 }.standardOutput.asText.map { it.trim().toIntOrNull() ?: 1 }
 
 val gitVersionName = providers.exec {
-    commandLine("git", "describe", "--tags", "--always")
+    // Match only version tags so the force-pushed `dev` tag can't shadow them.
+    commandLine("git", "describe", "--tags", "--match", "v*", "--always")
 }.standardOutput.asText.map { it.trim().removePrefix("v").ifEmpty { "0.0.0" } }
 
 android {


### PR DESCRIPTION
`versionName` comes from `git describe --tags`, but `dev-release.yml` force-pushes a `dev` tag onto the latest commit each merge. So `git describe --tags` selects `dev` and every build — including stable releases — gets a `dev` / `dev-N-g…` versionName. The published **v2.0.0 APK actually reports `versionName=dev`** (verified with aapt), which is why it shows as "dev" in system App Info and confuses update tooling (Obtainium).

Adds `--match "v*"` so describe only considers version tags; the `dev` tag can no longer shadow them.

- Stable build → `2.0.x`
- Dev build → `2.0.x-N-gSHA`

After this merges, cutting `v2.0.1` will produce an APK with `versionName=2.0.1` (and a higher versionCode), which updaters will correctly offer over the installed `dev`/132 build.

## Summary by Sourcery

Bug Fixes:
- Prevent the dev tag from overriding release tags when computing git-based versionName values.