### PR TITLE
security: bump AGP to 9.2.1 + Gradle wrapper to 9.4.1 (unblocks 32 alerts)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
 }
 
@@ -41,12 +40,11 @@ android {
         checkReleaseBuilds = true
     }
 
+    // With AGP 9's built-in Kotlin, the Kotlin jvmTarget follows
+    // targetCompatibility, so the old kotlinOptions block is redundant.
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = "17"
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.serialization) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "9.2.1"
-kotlin = "2.1.20"
-serialization = "1.8.10"
+kotlin = "2.2.10"
+serialization = "2.2.10"
 core-ktx = "1.17.0"
 appcompat = "1.7.1"
 material = "1.13.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,5 @@
 [versions]
 agp = "9.2.1"
-kotlin = "2.2.10"
 serialization = "2.2.10"
 core-ktx = "1.17.0"
 appcompat = "1.7.1"
@@ -22,5 +21,4 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "serialization" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.13.0"
+agp = "9.2.1"
 kotlin = "2.1.20"
 serialization = "1.8.10"
 core-ktx = "1.17.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Clears **31 of the 37** open Dependabot alerts on this repo. CI is green.

## Why Dependabot couldn't do this itself

Dependabot already opened #37 bumping `com.android.application` 8.13.0 → 9.2.1 — the right fix. But it had been failing CI since 2026-06-15:

```
Failed to apply plugin 'com.android.internal.version-check'.
> Minimum supported Gradle version is 9.4.1. Current version is 8.13.
```

AGP 9 requires Gradle ≥ 9.4.1, but the wrapper was still on 8.13, and **Dependabot bumps plugins but never the Gradle wrapper**. Its own security fix could never go green on its own. Getting to AGP 9 turned out to need three coordinated changes that Dependabot can't make in one PR, which is why this supersedes #37.

## What it fixes

| Package | Alerts | Path |
|---|---|---|
| netty (`codec-http`, `codec-http2`, `handler`, `codec`, `common`, `handler-proxy`) | 28 | `io.grpc:grpc-netty` → AGP |
| bouncycastle (`bcprov-jdk18on`, `bcpkix-jdk18on`) | 3 | direct AGP dependency |

AGP 9.2.1 **removes** the `io.grpc:*` and `org.bouncycastle:bcpkix-jdk18on` dependencies from its POM entirely, so these paths disappear rather than merely moving to patched versions. Verified by diffing the published POMs for `com.android.tools.build:gradle`:

- **8.13.0** declares `bcpkix-jdk18on:1.79`, `grpc-netty:1.69.1`, `grpc-core`, `grpc-protobuf`, `grpc-stub`, `grpc-inprocess`
- **9.2.1** declares none of them

## The three changes

1. **AGP 8.13.0 → 9.2.1** — the actual security fix.
2. **Gradle wrapper 8.13 → 9.4.1** — AGP 9's stated minimum. Without this the build won't configure at all.
3. **Migrate to AGP 9 built-in Kotlin** — AGP 9 enables built-in Kotlin by default and registers the `kotlin` extension itself, so applying `org.jetbrains.kotlin.android` on top always fails with `Cannot add extension with name 'kotlin'`, *regardless of KGP version* (I confirmed this the hard way by first trying to bump KGP to match — same failure). Per the [official migration guide](https://developer.android.com/build/migrate-to-built-in-kotlin), the plugin has to be removed:
   - dropped from the root and app build files, plus its version catalog entry (the `kotlin` version ref is now unused)
   - dropped `android.kotlinOptions`, which built-in Kotlin replaces — `jvmTarget` now defaults to `android.compileOptions.targetCompatibility`, already `VERSION_17`, so **the effective JVM target is unchanged**
   - the serialization compiler plugin needs no migration and still works; its version now tracks the Kotlin version AGP 9.2.1 bundles (2.2.10), rather than the badly stale 1.8.10 it was pinned to

## Important context on severity

**All 37 alerts are build-time only.** They come from the Gradle buildscript classpath (AGP's own tooling — bundletool, R8, aapt2), not from the app's runtime dependencies. The app itself depends only on core-ktx, appcompat, material, kotlinx-serialization, coroutines, and work-runtime — none of which pull in netty or bouncycastle. Nothing here ships in the APK, so the realistic exposure is the build machine, not users. Worth fixing, but this is not a "users are at risk" situation.

## What this does NOT fix (6 remaining alerts)

`protobuf-java`/`protobuf-kotlin` (2), `commons-compress` (2), `jdom2` (1), `jose4j` (1) — these arrive through other AGP-internal paths and aren't resolved by the AGP bump alone. Build-time only and lower severity. Worth a follow-up once this lands and the alert list re-scans.

## Verification

CI is green: **Build and Test** (`lintDebug` + `:app:testDebugUnitTest`, JDK 17) and **submit-gradle** both pass. Note `submit-gradle` was *also* failing before this PR on the same Kotlin plugin conflict, so this fixes that too.

Caveat worth stating plainly: I could not build this locally — Android builds need an x86_64 `aapt2` and my machine is ARM — so CI is the whole of the verification. Lint and unit tests passing means the build configures and compiles, but **no one has run the app**. Given this changes the Kotlin compilation path, a quick manual smoke test of the weather widget before merging is worth the two minutes.

I used Gradle 9.4.1 (AGP's stated minimum) rather than current stable 9.6.1 to keep the change minimal; bumping further is an easy follow-up.

Closes #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
