### PR TITLE
Fix background location updates for weather widget

### DIFF
--- a/app/src/main/java/com/wassupluke/widgets/MainActivity.kt
+++ b/app/src/main/java/com/wassupluke/widgets/MainActivity.kt
@@ -3,8 +3,10 @@ package com.wassupluke.widgets
 import android.Manifest
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.provider.Settings as SystemSettings
 import android.widget.Button
 import android.widget.RadioGroup
 import android.widget.SeekBar
@@ -36,10 +38,6 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
-    private val requestBackgroundLocation =
-        registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
-            Debug.log("BACKGROUND_LOCATION permission granted=$granted")
-        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -172,7 +170,19 @@ class MainActivity : AppCompatActivity() {
         ) == PackageManager.PERMISSION_GRANTED
         if (granted || Settings.backgroundLocationAsked(this)) return
         Settings.setBackgroundLocationAsked(this)
-        requestBackgroundLocation.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+        AlertDialog.Builder(this)
+            .setTitle(R.string.background_location_title)
+            .setMessage(R.string.background_location_message)
+            .setPositiveButton(R.string.background_location_open_settings) { _, _ ->
+                startActivity(
+                    Intent(
+                        SystemSettings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                        Uri.fromParts("package", packageName, null)
+                    )
+                )
+            }
+            .setNegativeButton(R.string.background_location_dismiss, null)
+            .show()
     }
 
     /** Re-render both widgets — used by the appearance settings they share. */

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,4 +27,8 @@
     <string name="alarm_tomorrow">Tomorrow</string>
     <string name="settings_alarm_tap_action">Alarm tap action</string>
     <string name="alarm_tap_default">Clock app</string>
+    <string name="background_location_title">Allow location all the time</string>
+    <string name="background_location_message">For the weather widget to update in the background, set the location permission to \"Allow all the time\" in the app settings.</string>
+    <string name="background_location_open_settings">Open Settings</string>
+    <string name="background_location_dismiss">Dismiss</string>
 </resources>


### PR DESCRIPTION
## Summary
- Widget weather was freezing between app opens because the OS denies background location *pulls* even with `ACCESS_BACKGROUND_LOCATION` — fixed by switching to OS-pushed `NETWORK` location updates via `PendingIntent` → `LocationUpdateReceiver` → `LocationCache`
- Added `LocationCache` with freshness checks (2h max age, future-timestamp guard) so the widget never shows stale-location weather
- Centralized refresh interval constant, hardened partial-write guards, and switched raw `Log` calls to the `Debug` wrapper
- Replaced the unreliable system background-location permission launcher with an `AlertDialog` guiding the user to enable "Allow all the time" in app settings

## Test plan
- [x] Unit tests for `LocationCache` encode/decode, freshness, and partial-write handling (29 tests green)
- [ ] Install debug APK, grant "While using the app" location — verify dialog appears explaining background permission
- [ ] Tap "Open Settings" in dialog — verify it opens the app's permission settings
- [ ] Enable "Allow all the time", place weather widget, leave app idle for 30+ min — verify weather updates
- [ ] Reboot device — verify heartbeat and background location re-register on boot

## Summary by Sourcery

Improve background location permission UX to support reliable weather widget updates.

New Features:
- Show an in-app dialog explaining the need for "Allow all the time" location access for background weather updates and guiding users to app settings.

Enhancements:
- Replace the direct background location permission request with a settings-deep-link flow triggered from the new dialog.