### PR TITLE
Dev build identity + in-app version display

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -34,14 +34,14 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build Release APK
-        run: ./gradlew assembleRelease
+      - name: Build Dev APK
+        run: ./gradlew assembleDev
 
       - name: Sign APK
         id: sign_app
         uses: r0adkll/sign-android-release@v1
         with:
-          releaseDirectory: app/build/outputs/apk/release
+          releaseDirectory: app/build/outputs/apk/dev
           signingKeyBase64: ${{ secrets.SIGNING_KEY }}
           alias: ${{ secrets.ALIAS }}
           keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 JDK 17+ (source/target 17; JDK 21 runs the build fine). Requires `local.properties` with `sdk.dir=<android-sdk-path>` (gitignored — create it locally; the build fails without it).
 
 - Debug build / install: `./gradlew :app:assembleDebug` / `./gradlew :app:installDebug`. The debug build has `applicationIdSuffix = ".debug"` (+ `versionNameSuffix` and a debug-only `app_name` in `src/debug/res`) so it installs **alongside** a release build for on-device testing without disturbing it.
+- There are **three** build types: `debug`, `release`, and `dev`. `dev` (`assembleDev`) is the prerelease published by `dev-release.yml`; it `initWith(release)` (same minify/shrink/proguard) but adds `applicationIdSuffix = ".dev"`, `versionNameSuffix = "-dev"`, and its own `app_name` (`src/dev/res`) so it too installs **alongside** a real release. Its `versionName` (e.g. `2.0.4-20-g67e1446-dev`) carries the commit hash via `git describe`.
 - All unit tests: `./gradlew :app:testDebugUnitTest`
 - One test class: `./gradlew :app:testDebugUnitTest --tests "com.wassupluke.widgets.WeatherCodeTest"`
 - Lint: `./gradlew lintDebug` (`abortOnError = true`, so lint failures break the build — CI runs this too).
@@ -16,7 +17,7 @@ JDK 17+ (source/target 17; JDK 21 runs the build fine). Requires `local.properti
 
 **Versioning is git-derived** (`app/build.gradle.kts`): `versionCode` = `git rev-list --count HEAD`, `versionName` = `git describe --tags --always`. A build needs real git history with tags — a shallow/zero-depth checkout yields a wrong version (hence the full-depth checkout in CI).
 
-**CI** (`.github/workflows/`): `check.yml` runs lint + unit tests on PRs/pushes to `main`; `dev-release.yml` builds, signs, and publishes a prerelease to the force-pushed `dev` tag on every push to `main`; `release.yml` does the same for `v*` tags. Release builds are signed via repo secrets (`SIGNING_KEY`/`ALIAS`/…) — there is no committed keystore.
+**CI** (`.github/workflows/`): `check.yml` runs lint + unit tests on PRs/pushes to `main`; `dev-release.yml` builds (`assembleDev`), signs, and publishes a prerelease to the force-pushed `dev` tag on every push to `main`; `release.yml` does the same for `v*` tags. Release builds are signed via repo secrets (`SIGNING_KEY`/`ALIAS`/…) — there is no committed keystore.
 
 ## Architecture
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,10 +16,6 @@ val gitShortHash = providers.exec {
     commandLine("git", "rev-parse", "--short", "HEAD")
 }.standardOutput.asText.map { it.trim().ifEmpty { "unknown" } }
 
-// The dev prerelease is versioned as the *upcoming* release: the latest v* tag with its patch
-// bumped, plus the short commit hash — e.g. tag v2.0.5 at HEAD e11bcb2 -> "v2.0.6-dev-e11bcb2".
-// Fully derived from git (the tag is the part of gitVersionName's "<tag>-<n>-g<hash>" describe
-// before the first "-"), nothing hardcoded.
 val devVersionName = gitVersionName.zip(gitShortHash) { describe, shortHash ->
     val parts = describe.substringBefore("-").split(".").toMutableList()
     parts.lastOrNull()?.toIntOrNull()?.let { parts[parts.lastIndex] = (it + 1).toString() }
@@ -38,17 +34,12 @@ android {
         versionName = gitVersionName.get()
     }
 
-    // BuildConfig.DEBUG gates the Debug logcat wrapper; AGP 9 doesn't generate
-    // BuildConfig unless it's asked for.
     buildFeatures {
         buildConfig = true
     }
 
     buildTypes {
         debug {
-            // Coexist with an installed release build so on-device testing doesn't disturb it.
-            // The suffixed version name and the debug-only app_name (src/debug/res) keep the two
-            // installs tellable apart on-device — they share an icon otherwise.
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-debug"
         }
@@ -60,10 +51,7 @@ android {
                 "proguard-rules.pro"
             )
         }
-        // The prerelease "dev" build published from main by dev-release.yml. Inherits the release
-        // config (minify/shrink/proguard) but gets its own applicationId + app name (src/dev/res)
-        // so it installs alongside a real release. Its versionName is fully replaced below (per
-        // variant) with `devVersionName` rather than suffixed here.
+
         create("dev") {
             initWith(getByName("release"))
             applicationIdSuffix = ".dev"
@@ -75,18 +63,12 @@ android {
         checkReleaseBuilds = true
     }
 
-    // With AGP 9's built-in Kotlin, the Kotlin jvmTarget follows
-    // targetCompatibility, so the old kotlinOptions block is redundant.
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
 }
 
-// Replace (not just suffix) the dev variant's versionName so it reads like the upcoming release,
-// e.g. "v2.0.5-dev-67e1446". Scoped to the dev build type, so release/debug are untouched. This
-// sets the manifest versionName; the in-app "Version …" line reads it back via PackageManager
-// (not BuildConfig, which an output override doesn't reliably reach) so the two always match.
 androidComponents {
     onVariants(selector().withBuildType("dev")) { variant ->
         val name = devVersionName.get()

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,6 +12,20 @@ val gitVersionName = providers.exec {
     commandLine("git", "describe", "--tags", "--match", "v*", "--always")
 }.standardOutput.asText.map { it.trim().removePrefix("v").ifEmpty { "0.0.0" } }
 
+val gitShortHash = providers.exec {
+    commandLine("git", "rev-parse", "--short", "HEAD")
+}.standardOutput.asText.map { it.trim().ifEmpty { "unknown" } }
+
+// The dev prerelease is versioned as the *upcoming* release: the latest v* tag with its patch
+// bumped, plus the short commit hash — e.g. tag v2.0.5 at HEAD e11bcb2 -> "v2.0.6-dev-e11bcb2".
+// Fully derived from git (the tag is the part of gitVersionName's "<tag>-<n>-g<hash>" describe
+// before the first "-"), nothing hardcoded.
+val devVersionName = gitVersionName.zip(gitShortHash) { describe, shortHash ->
+    val parts = describe.substringBefore("-").split(".").toMutableList()
+    parts.lastOrNull()?.toIntOrNull()?.let { parts[parts.lastIndex] = (it + 1).toString() }
+    "v${parts.joinToString(".")}-dev-$shortHash"
+}
+
 android {
     namespace = "com.wassupluke.widgets"
     compileSdk = 36
@@ -48,12 +62,11 @@ android {
         }
         // The prerelease "dev" build published from main by dev-release.yml. Inherits the release
         // config (minify/shrink/proguard) but gets its own applicationId + app name (src/dev/res)
-        // so it installs alongside a real release, and a "-dev" version marker. The commit hash is
-        // already carried by versionName via `git describe` (e.g. 2.0.4-20-g67e1446-dev).
+        // so it installs alongside a real release. Its versionName is fully replaced below (per
+        // variant) with `devVersionName` rather than suffixed here.
         create("dev") {
             initWith(getByName("release"))
             applicationIdSuffix = ".dev"
-            versionNameSuffix = "-dev"
         }
     }
 
@@ -67,6 +80,17 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+// Replace (not just suffix) the dev variant's versionName so it reads like the upcoming release,
+// e.g. "v2.0.5-dev-67e1446". Scoped to the dev build type, so release/debug are untouched. This
+// sets the manifest versionName; the in-app "Version …" line reads it back via PackageManager
+// (not BuildConfig, which an output override doesn't reliably reach) so the two always match.
+androidComponents {
+    onVariants(selector().withBuildType("dev")) { variant ->
+        val name = devVersionName.get()
+        variant.outputs.forEach { it.versionName.set(name) }
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,15 @@ android {
                 "proguard-rules.pro"
             )
         }
+        // The prerelease "dev" build published from main by dev-release.yml. Inherits the release
+        // config (minify/shrink/proguard) but gets its own applicationId + app name (src/dev/res)
+        // so it installs alongside a real release, and a "-dev" version marker. The commit hash is
+        // already carried by versionName via `git describe` (e.g. 2.0.4-20-g67e1446-dev).
+        create("dev") {
+            initWith(getByName("release"))
+            applicationIdSuffix = ".dev"
+            versionNameSuffix = "-dev"
+        }
     }
 
     lint {

--- a/app/src/dev/res/values/strings.xml
+++ b/app/src/dev/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Overrides the main sourceset so the dev prerelease install (applicationIdSuffix ".dev")
+         is distinguishable from a real release install sitting next to it — they share an icon. -->
+    <string name="app_name">µWidgets dev</string>
+</resources>

--- a/app/src/main/java/com/wassupluke/widgets/MainActivity.kt
+++ b/app/src/main/java/com/wassupluke/widgets/MainActivity.kt
@@ -151,6 +151,9 @@ class MainActivity : AppCompatActivity() {
             render = { AlarmWidgetProvider.renderAlarmWidgets(this) },
         )
 
+        findViewById<TextView>(R.id.version_info).text =
+            getString(R.string.settings_version, BuildConfig.VERSION_NAME)
+
         if (!hasPermission()) {
             requestPermission.launch(Manifest.permission.ACCESS_COARSE_LOCATION)
         } else {

--- a/app/src/main/java/com/wassupluke/widgets/MainActivity.kt
+++ b/app/src/main/java/com/wassupluke/widgets/MainActivity.kt
@@ -151,8 +151,11 @@ class MainActivity : AppCompatActivity() {
             render = { AlarmWidgetProvider.renderAlarmWidgets(this) },
         )
 
+        // Read the installed manifest versionName (not BuildConfig) so it reflects the dev
+        // variant's per-variant versionName override, e.g. "v2.0.5-dev-67e1446".
+        val versionName = packageManager.getPackageInfo(packageName, 0).versionName
         findViewById<TextView>(R.id.version_info).text =
-            getString(R.string.settings_version, BuildConfig.VERSION_NAME)
+            getString(R.string.settings_version, versionName)
 
         if (!hasPermission()) {
             requestPermission.launch(Manifest.permission.ACCESS_COARSE_LOCATION)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -169,5 +169,15 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="24dp" />
+
+        <TextView
+            android:id="@+id/version_info"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            android:textColor="?android:attr/textColorSecondary"
+            android:layout_marginTop="24dp"
+            android:paddingBottom="24dp"
+            tools:text="Version 2.0.4-20-g67e1446" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -174,10 +174,9 @@
             android:id="@+id/version_info"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textSize="14sp"
+            android:textAppearance="?android:attr/textAppearanceSmall"
             android:textColor="?android:attr/textColorSecondary"
-            android:layout_marginTop="24dp"
-            android:paddingBottom="24dp"
-            tools:text="Version 2.0.4-20-g67e1446" />
+            android:layout_marginTop="@dimen/settings_section_spacing"
+            android:paddingBottom="@dimen/settings_section_spacing" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Vertical gap between Settings sections. -->
+    <dimen name="settings_section_spacing">24dp</dimen>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,4 +33,5 @@
     <string name="background_location_dismiss">Not now</string>
     <string name="background_data_title">Allow background data</string>
     <string name="background_data_message">The weather widget may stop updating on metered networks (such as mobile data or a Wi‑Fi hotspot) if background data is not allowed; it is recommended to turn this setting on.</string>
+    <string name="settings_version">Version %1$s</string>
 </resources>


### PR DESCRIPTION
Two related changes around build identity and version visibility.

## 1. Dedicated `dev` build type
The dev prerelease was built as a plain `release` variant, so it shared the production **app name** and **applicationId** — it overwrote a real release install instead of coexisting.

- New `dev` build type: `initWith(release)` (same minify/shrink/proguard) + `applicationIdSuffix = ".dev"`, `versionNameSuffix = "-dev"`, and its own `app_name` via `src/dev/res` (`µWidgets dev`).
- `dev-release.yml` now runs `assembleDev` and signs `app/build/outputs/apk/dev`.
- `versionName` keeps the commit hash from `git describe` (mirrors jrpie/launcher's approach of surfacing the hash).

Verified APK badging: `package: name='com.wassupluke.widgets.dev' versionName='2.0.4-20-g67e1446-dev'`, `application-label:'µWidgets dev'` — installs alongside a release.

## 2. In-app version display
A subtle version line at the bottom of the Settings screen, read live from `BuildConfig.VERSION_NAME`.

Verified on-device: bottom of Settings shows e.g. `Version 2.0.4-21-g5429f7f-debug`.

`lintDebug` + `testDebugUnitTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a dedicated dev build variant and surface the app version in the settings UI.

New Features:
- Add a dev build type that builds a separately installable prerelease APK with distinct application ID, version suffix, and app name.
- Display the current version name at the bottom of the settings screen using BuildConfig.VERSION_NAME.

Build:
- Configure Gradle to create a dev build type inheriting release settings but with dev-specific ID and version suffixes.

CI:
- Update the dev-release GitHub Actions workflow to build and sign the dev APK output directory.

Documentation:
- Document the new dev build type and updated dev-release CI workflow in CLAUDE.md.