### PR TITLE
ci: use gradle/actions/setup-gradle for build caching

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -1,0 +1,18 @@
+name: Gradle setup
+description: Set up JDK 17, the Gradle build cache, and make gradlew executable.
+
+runs:
+  using: composite
+  steps:
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Set up Gradle
+      uses: gradle/actions/setup-gradle@v4
+
+    - name: Grant execute permission for gradlew
+      shell: bash
+      run: chmod +x gradlew

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,7 +29,9 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,17 +24,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+        uses: ./.github/actions/gradle-setup
 
       - name: Run Lint
         run: ./gradlew lintDebug

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -29,7 +29,9 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -24,17 +24,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+        uses: ./.github/actions/gradle-setup
 
       - name: Build Dev APK
         run: ./gradlew assembleDev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,9 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,17 +18,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+        uses: ./.github/actions/gradle-setup
 
       - name: Build Release APK
         run: ./gradlew assembleRelease

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,6 @@ kotlin.code.style=official
 # Increase heap size for Gradle daemon
 org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.configuration-cache=true
+org.gradle.caching=true
 
 android.useAndroidX=true


### PR DESCRIPTION
Switches all three workflows from `setup-java`'s `cache: gradle` to [`gradle/actions/setup-gradle@v4`](https://github.com/gradle/actions), the Gradle-team-recommended approach.

## Why
- **Caches more:** the Gradle *build cache* (compiled task outputs — Kotlin compilation, resource processing) on top of dependency downloads.
- **Write-safe keying:** only *writes* the cache from `main`; PRs read it. Stops PR branches from thrashing the cache / blowing the 10 GB repo limit.
- **Cache report** in each job summary (hit/miss visibility).

## Changes
- `gradle.properties`: `org.gradle.caching=true` (configuration cache was already enabled).
- `check.yml`, `dev-release.yml`, `release.yml`: drop `cache: gradle` from `setup-java`, add a `setup-gradle` step.

## Verification
`./gradlew :app:testDebugUnitTest` passes locally with the build cache enabled. CI caching itself only demonstrates a hit once this is on `main` and a second run follows.

## Summary by Sourcery

Enable Gradle build caching and adopt the recommended Gradle setup action in CI workflows.

Enhancements:
- Turn on Gradle build caching globally via gradle.properties configuration.

CI:
- Replace setup-java Gradle caching with gradle/actions/setup-gradle in check, dev-release, and release workflows to improve cache behavior and visibility.